### PR TITLE
Fix random contention bug

### DIFF
--- a/ag-player/src/main/java/com/sematext/ag/player/RealTimePlayer.java
+++ b/ag-player/src/main/java/com/sematext/ag/player/RealTimePlayer.java
@@ -27,6 +27,7 @@ import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Simulates constant real-time user load: users using service with reasonable delays between actions.
@@ -115,7 +116,8 @@ public class RealTimePlayer extends Player {
     public void run() {
       long startTime = System.currentTimeMillis();
       while (System.currentTimeMillis() < startTime + timeToWork && sourceGroup.size() > 0) {
-        int sourceIndex = (int) (Math.random() * sourceGroup.size());
+        Random r = new Random();
+        int sourceIndex = r.nextInt(sourceGroup.size());
         Source source = sourceGroup.get(sourceIndex);
         Event event = source.nextEvent();
         if (null == event) {
@@ -134,7 +136,7 @@ public class RealTimePlayer extends Player {
         }
         try {
           if (sourceGroup.size() > 0) {
-            long sleepTime = (long) ((minActionDelay + Math.random() * (maxActionDelay - minActionDelay)) / sourceGroup
+            long sleepTime = (long) ((minActionDelay + r.nextDouble() * (maxActionDelay - minActionDelay)) / sourceGroup
                 .size());
             Thread.sleep(sleepTime);
           }


### PR DESCRIPTION
In RealTimePlayer.java, Math.random() is used for random number generation. 
According to[ Java API ](http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#random--), it's suggested that each thread has their own random number generator to reduce contention.
The increasing in contention might have a significant effect since the random number generation is 
in Thread implementation. 
This pull request improved the condition by replacing Math.random() with Random.nextInt().